### PR TITLE
[ENG-1006] Default log execution id if it is not set

### DIFF
--- a/modules/gcp_api/functions.tf
+++ b/modules/gcp_api/functions.tf
@@ -46,7 +46,19 @@ resource "google_cloudfunctions2_function" "this" {
     service_account_email = each.value.service_account_email
 
     environment_variables = {
-      for e in each.value.environment_variables : e.name => e.value
+      for e in concat(
+        each.value.environment_variables,
+        # If one isn't explicitly declared add a LOG_EXECUTION_ID variable (as GCP will do this anyway)
+        contains(
+          [for e in each.value.environment_variables : e.name],
+          "LOG_EXECUTION_ID"
+          ) ? [] : [
+          {
+            name  = "LOG_EXECUTION_ID",
+            value = true,
+          }
+        ]
+      ) : e.name => e.value
     }
   }
 }


### PR DESCRIPTION
## Description

- Add in LOG_EXECUTION_ID as an env var if not set

## Issue(s)

[ENG-1006](https://www.notion.so/oaknationalacademy/BUG-Properly-handle-LOG_EXECUTION_ID-variable-12026cc4e1b1805f9407d4f8a913ffc1?pvs=4)

## How to test

1. Remove the `LOG_EXECUTION_ID` from any existing module and see that nothing changes

## Checklist


