### PR TITLE
[ENG-1085] Add region to the name of instances

### DIFF
--- a/modules/gcp_sql/instance.tf
+++ b/modules/gcp_sql/instance.tf
@@ -7,7 +7,9 @@ locals {
     "16"  = "db-custom-4-16384" # 4 vCPU
   }
 
-  name = "${var.name_parts.domain}-${var.env}-${var.name_parts.app}-${var.name_parts.resource}"
+  name = join("-", [
+    var.name_parts.domain, var.env, var.name_parts.region, var.name_parts.app, var.name_parts.resource
+  ])
 
   authorized_network_records = {
     for an in var.authorized_networks : an.cidr => an.description


### PR DESCRIPTION
## Description

- Add region to the name
- Refactor to use a join to create the name

## Issue(s)

[ENG-1085](https://www.notion.so/oaknationalacademy/Bug-Add-the-region-to-the-instance-name-17626cc4e1b180889828c35c4a74d963?pvs=4)

## How to test

1. Build an instance

## Checklist


