### PR TITLE
ENG-1097: Allow write permissions to be granted to a bucket

### DIFF
--- a/modules/gcp_sql/instance.tf
+++ b/modules/gcp_sql/instance.tf
@@ -64,3 +64,12 @@ resource "google_sql_database_instance" "this" {
     }
   }
 }
+
+resource "google_storage_bucket_iam_member" "this" {
+  for_each = toset(compact([var.export_bucket]))
+
+  bucket = each.key
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_sql_database_instance.this.service_account_email_address}"
+}
+

--- a/modules/gcp_sql/variables.tf
+++ b/modules/gcp_sql/variables.tf
@@ -85,3 +85,10 @@ variable "high_availability" {
   type        = bool
   default     = false
 }
+
+variable "export_bucket" {
+  description = "A bucket the instance will have access to for exports"
+  type        = string
+  nullable    = true
+  default     = null
+}


### PR DESCRIPTION
## Description

- If a bucket is specified grant object access to enable the export function to work

## Issue(s)

[ENG-1097](https://www.notion.so/oaknationalacademy/Grant-SQL-instances-bucket-access-18226cc4e1b180fb9ec0c220dc2e610f?pvs=4)

## How to test

1. Run an plan with the export bucket variable set and see it attempts to create some bucket iam permissions

## Checklist


