### PR TITLE
[Eng 1118] Upgrade google provider version

### DIFF
--- a/examples/gcp_api/terraform.tf
+++ b/examples/gcp_api/terraform.tf
@@ -8,11 +8,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "5.2.0"
+      version = "6.19.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.77.0"
+      version = "6.19.0"
     }
   }
 }

--- a/modules/gcp_api/terraform.tf
+++ b/modules/gcp_api/terraform.tf
@@ -8,11 +8,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "5.2.0"
+      version = "6.19.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.77.0"
+      version = "6.19.0"
     }
   }
 }


### PR DESCRIPTION
## Description

- Upgrades Google provider version to `6.19.0` to leverage the latest features, fixes and improvements. 
- Renamed `versions.tf` to `terraform.tf` for consistency

## Issue(s)

[ENG-1118](https://www.notion.so/oaknationalacademy/Upgrade-the-Google-Provider-API-module-18f26cc4e1b1800faafff3abee47fe9b)

## How to test

Run `terraform plan`

## Checklist

- [ ] Ensure Terraform plan shows no changes for all workspaces
- [ ] Apply the changes the Terraform


