### PR TITLE
[Eng 1121] Upgrade google provider version

### DIFF
--- a/modules/gcp_firestore/terraform.tf
+++ b/modules/gcp_firestore/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.2.0"
+      version = "6.19.0"
     }
   }
 }


### PR DESCRIPTION
## Description

- Upgrades Google provider version to `6.19.0` to leverage the latest features, fixes and improvements. 
- Renamed `versions.tf` to `terraform.tf` for consistency

## Issue(s)

[ENG-1121](https://www.notion.so/oaknationalacademy/Upgrade-the-Google-Provider-API-module-18f26cc4e1b1800faafff3abee47fe9b)

## How to test

Run `terraform plan`

## Checklist

- [ ] Ensure Terraform plan shows no changes for all workspaces
- [ ] Apply the changes the Terraform
