### PR TITLE
[Eng 1151] Upgrade google provider version 

### DIFF
--- a/modules/gcp_sql/terraform.tf
+++ b/modules/gcp_sql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.1.0"
+      version = "6.19.0"
     }
   }
 }


### PR DESCRIPTION
## Description

- Upgrades Google provider version to `6.19.0` to leverage the latest features, fixes and improvements. 
- Renamed `versions.tf` to `terraform.tf` for consistency

## Issue(s)

[ENG-1151](https://www.notion.so/oaknationalacademy/Upgrade-the-Google-Provider-Firestore-module-18f26cc4e1b1808981cefa6c0536f331)

## How to test

Run `terraform plan`

## Checklist

- [ ] Ensure Terraform plan shows no changes for all workspaces
- [ ] Apply the changes the Terraform
