### PR TITLE
[ENG-784] Delete Firestore on workspace delete

### DIFF
--- a/modules/gcp_firestore/main.tf
+++ b/modules/gcp_firestore/main.tf
@@ -10,6 +10,8 @@ resource "google_firestore_database" "this" {
   app_engine_integration_mode = "DISABLED"
 
   point_in_time_recovery_enablement = lookup(var.backup, "point_in_time", false) ? "POINT_IN_TIME_RECOVERY_ENABLED" : "POINT_IN_TIME_RECOVERY_DISABLED"
+  delete_protection_state           = var.env == "prod" ? "DELETE_PROTECTION_ENABLED" : "DELETE_PROTECTION_DISABLED"
+  deletion_policy                   = "DELETE"
 }
 
 locals {


### PR DESCRIPTION
## Description

- In google provider V4, when a Firestore is deleted or the workspace destroyed, the Firebase resource is not removed. A functionality has been added in v6 to enable us do this; `delete_protection_state` and `deletion_policy`. 
- Added `DELETE_PROTECTION_ENABLED` for prod to prevent accidental deletions.

## Issue(s)

[ENG-784](https://www.notion.so/oaknationalacademy/Delete-Firestore-on-workspace-delete-e8806ee9770f4542a7d73c06c8247c10)

## How to test
Run terraform plan

## Checklist

- [ ] All production firebase resources are delete protected
- [ ]  Firebase resources are deleted when their resources are removed from Terraform

