### PR TITLE
[ENG-1082] Enable deletion protection in GCP

### DIFF
--- a/modules/gcp_sql/instance.tf
+++ b/modules/gcp_sql/instance.tf
@@ -27,7 +27,8 @@ resource "google_sql_database_instance" "this" {
     tier      = local.tier_lookup[var.memory]
     disk_type = "PD_SSD"
 
-    availability_type = var.high_availability ? "REGIONAL" : "ZONAL"
+    availability_type           = var.high_availability ? "REGIONAL" : "ZONAL"
+    deletion_protection_enabled = var.deletion_protection
 
     dynamic "backup_configuration" {
       for_each = toset((var.backup.backup_retention + var.backup.transaction_log_retention) > 0 ? [{}] : [])


### PR DESCRIPTION
## Description

- Enable deletion protection at GCP level (it's currently only within Terraform).

## Issue(s)

[ENG-1082](https://www.notion.so/oaknationalacademy/Create-a-new-production-user-data-database-instance-17426cc4e1b180a0a0fcee8b71cb4d5f?pvs=4)

## How to test

1. Run an apply using the module and see the flag change


