### PR TITLE
[ENG-1239] Adds functionality for custom environments

### DIFF
--- a/modules/vercel_project/dns.tf
+++ b/modules/vercel_project/dns.tf
@@ -5,10 +5,10 @@ data "cloudflare_zone" "this" {
 }
 
 resource "cloudflare_dns_record" "this" {
-  for_each = toset(var.domains)
+  for_each = { for domain in local.all_domains : domain.name => domain }
 
   zone_id = data.cloudflare_zone.this.zone_id
-  name    = replace(each.value, "/\\.?${var.cloudflare_zone_domain}$/", "")
+  name    = replace(each.value.name, "/\\.?${var.cloudflare_zone_domain}$/", "")
   type    = "CNAME"
   content = "cname.vercel-dns.com"
   proxied = true

--- a/modules/vercel_project/dns.tf
+++ b/modules/vercel_project/dns.tf
@@ -8,7 +8,7 @@ resource "cloudflare_dns_record" "this" {
   for_each = { for domain in local.all_domains : domain.name => domain }
 
   zone_id = data.cloudflare_zone.this.zone_id
-  name    = replace(each.value.name, "/\\.?${var.cloudflare_zone_domain}$/", "")
+  name    = each.value.name
   type    = "CNAME"
   content = "cname.vercel-dns.com"
   proxied = true

--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -32,6 +32,7 @@ resource "vercel_project" "this" {
   framework                        = var.framework
   build_command                    = var.build_command
   ignore_command                   = var.ignore_command
+  install_command                  = var.install_command
   skew_protection                  = var.skew_protection
   protection_bypass_for_automation = var.protection_bypass_for_automation
   output_directory                 = var.output_directory

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -112,8 +112,15 @@ variable "git_repo" {
     error_message = "The git_repo must be in the format 'owner/repository' (e.g., 'oaknational/Oak-Web-Application')."
   }
 }
+
 variable "ignore_command" {
   description = "Command to determine if build should be skipped"
+  type        = string
+  default     = null
+}
+
+variable "install_command" {
+  description = "The install command for the project"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description

- Allows custom environment with tn.a domain and environment variables attached to be created

- Cloudflare `v5.6.0` accepts both FQDN and name, but always want to update in place from `owa-vercel.thenational.academy -> owa-vercel` when you run terraform commands. Using the FQDN solves this

## Issue(s)

[ENG-1239](https://www.notion.so/oaknationalacademy/Enable-Custom-environments-in-Vercel-21626cc4e1b1801d848dc1d2e9140885)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

