### PR TITLE
[ENG-1240] Remove sensitive feature in custom environments

### DIFF
--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -54,6 +54,7 @@ resource "vercel_project_domain" "this" {
   project_id            = vercel_project.this.id
   domain                = each.key
   custom_environment_id = try(vercel_custom_environment.this[each.value.custom_environment_name].id, null)
+  git_branch            = var.git_branch
 }
 
 resource "vercel_project_environment_variables" "this" {

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -103,6 +103,12 @@ variable "framework" {
   default     = "nextjs"
 }
 
+variable "git_branch" {
+  description = "Git branch to link to the project domain"
+  type        = string
+  default     = null
+}
+
 variable "git_repo" {
   description = "Git repository URL"
   type        = string


### PR DESCRIPTION
## Description

- We are only supporting non-sensitive variables in custom environments for now
- Adds support for `git_branch`. This allows us choose what branch to link to the project domain for the OWA-storybook

## Issue(s)

[ENG-1240](https://www.notion.so/oaknationalacademy/Create-owa-staging-on-Vercel-21626cc4e1b180dbabc8cfe39c6d71df)

[ENG-1254](https://www.notion.so/oaknationalacademy/Put-Storybook-live-on-Vercel-21826cc4e1b180ff97d7c8bb68a92a5e)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

