### PR TITLE
[ENG-1240] Add sensitive in custom envs

### DIFF
--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -14,13 +14,10 @@ locals {
   )
 
   custom_env_vars = [
-    for cev in var.custom_env_vars : {
-      key   = cev.key
-      value = cev.value
-      custom_environment_ids = [
+    for cev in var.custom_env_vars : merge(cev,
+      { custom_environment_ids = [
         vercel_custom_environment.this[cev.custom_environment_name].id
-      ]
-    }
+    ] })
   ]
 
   all_env_vars = concat(var.environment_variables, local.custom_env_vars)
@@ -63,6 +60,7 @@ resource "vercel_project_environment_variables" "this" {
     for ev in local.all_env_vars : {
       key                    = ev.key
       value                  = ev.value
+      sensitive              = ev.sensitive
       target                 = try(ev.target, null)
       custom_environment_ids = try(ev.custom_environment_ids, null)
     }

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -40,6 +40,7 @@ variable "custom_env_vars" {
     key                     = string
     value                   = string
     custom_environment_name = string
+    sensitive               = optional(bool, false)
   }))
   default = []
   validation {


### PR DESCRIPTION

## Description

- Although, we are only supporting non-sensitive variables in custom environments for now, the default value for `sensitive` is `true` and we'll like to set the custom env var sensitive value to `false`

https://github.com/vercel/terraform-provider-vercel/blob/87fce8a0276d22d9bd491a07cc1e2fbb8f17dd93/vercel/resource_project_environment_variables.go#L134C7-L138C82

## Issue(s)

[ENG-1240](https://www.notion.so/oaknationalacademy/Create-owa-staging-on-Vercel-21626cc4e1b180dbabc8cfe39c6d71df)

## How to test

1. Check that the value for the custom environment variable is not sensitive

## Checklist

- [ ] Something that needs doing

