### PR TITLE
[ENG-1303] Increase memory

### DIFF
--- a/modules/gcp_job/jobs.tf
+++ b/modules/gcp_job/jobs.tf
@@ -26,7 +26,7 @@ resource "google_cloud_run_v2_job" "this" {
         resources {
           limits = {
             cpu    = "1000m"
-            memory = "1024Mi"
+            memory = "2048Mi"
           }
         }
       }


### PR DESCRIPTION

## Description

- bulk-download job out of memory which is causing it fail

## Issue(s)

[ENG-1303](https://www.notion.so/oaknationalacademy/Increase-Cloud-run-job-memory-24d26cc4e1b180719382dab260d21ee3)

## How to test

1. bulk download job suceeds

## Checklist

- [ ] Something that needs doing

