### PR TITLE
[ENG-1308] Sets Vercel projects to private by default

### DIFF
--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -5,6 +5,8 @@ locals {
 
   project_name = "${local.normalized_repo}-${var.build_type}"
 
+  deployment_type = var.project_visibility == "private" ? "all_deployments" : "standard_protection_new"
+
   all_domains = concat(
     [for domain in var.domains : { name = domain }],
     [for ce in var.custom_environments : {
@@ -40,11 +42,13 @@ resource "vercel_project" "this" {
   ignore_command                                    = var.ignore_command
   install_command                                   = var.install_command
   skew_protection                                   = var.skew_protection
+  preview_deployments_disabled                      = true
   protection_bypass_for_automation                  = var.protection_bypass_for_automation
   output_directory                                  = var.output_directory
 
+
   vercel_authentication = {
-    deployment_type = var.deployment_type
+    deployment_type = local.deployment_type
   }
 
   root_directory = var.root_directory

--- a/modules/vercel_project/terraform.tf
+++ b/modules/vercel_project/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 3.5.1"
+      version = "~> 3.13.0"
     }
   }
 }

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -64,11 +64,6 @@ EOT
   }
 }
 
-variable "deployment_type" {
-  description = "The deployment environment to protect."
-  type        = string
-}
-
 variable "domains" {
   description = "Custom domains"
   type        = list(string)
@@ -147,6 +142,17 @@ variable "production_branch" {
   description = "Branch name that triggers production deploys"
   type        = string
   default     = "main"
+}
+
+variable "project_visibility" {
+  description = "Can be either private (all domains are behind login) or public (custom domains are publicly available)"
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["private", "public"], var.project_visibility)
+    error_message = "Project visibility must be either 'private' or 'public'."
+  }
 }
 
 variable "protection_bypass_for_automation" {


### PR DESCRIPTION

## Description

- New projects now default to private (all deployments behind auth login)
- Added project_visibility variable to toggle between private/public
- Default production branch domain is not created by default
- Custom domains are publicly available

## Issue(s)

[ENG-1308]()

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

