### PR TITLE
fix: enable vercel preview deployments

### DIFF
--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -42,7 +42,6 @@ resource "vercel_project" "this" {
   ignore_command                                    = var.ignore_command
   install_command                                   = var.install_command
   skew_protection                                   = var.skew_protection
-  preview_deployments_disabled                      = true
   protection_bypass_for_automation                  = var.protection_bypass_for_automation
   output_directory                                  = var.output_directory
 


### PR DESCRIPTION


## Description

- set `preview_deployments_disabled` back to false to restore git push deployments. it defaults to `false`

## Issue(s)

[ENG-1317](https://www.notion.so/oaknationalacademy/Fix-Enable-preview-deployments-26126cc4e1b180c3853fcb157f059ed8)

## How to test

1. check that vercel deployments are created on PRs

## Checklist

- [ ] Something that needs doing

