### PR TITLE
[ENG-1484] Add project_id variable to gcp_firestore module

### DIFF
--- a/modules/gcp_firestore/main.tf
+++ b/modules/gcp_firestore/main.tf
@@ -1,4 +1,5 @@
 resource "google_firestore_database" "this" {
+  project = var.project_id
   name = join("-", [
     var.name_parts.domain, var.env, var.name_parts.region, var.name_parts.app, var.name_parts.resource
   ])
@@ -22,6 +23,8 @@ locals {
 
 resource "google_firestore_backup_schedule" "this" {
   count = contains(["d", "w"], var.backup.frequency) ? 1 : 0
+
+  project = var.project_id
 
   database = google_firestore_database.this.name
 

--- a/modules/gcp_firestore/variables.tf
+++ b/modules/gcp_firestore/variables.tf
@@ -35,6 +35,12 @@ variable "env" {
   }
 }
 
+variable "project_id" {
+  description = "The Google Cloud project ID"
+  type        = string
+  default     = null
+}
+
 variable "region" {
   description = "The Google Cloud region name"
   type        = string


### PR DESCRIPTION


## Description

- Added project variable to all Firestore resources and exposed it as a module input.
This is because we are migrating from a single workspace per GCP project setup (pupil-api-prod, pupil-api-beta) to a single workspace managing multiple GCP projects in vercel(OWA) where the provider cant workout the target project to use.

## Issue(s)

[ENG-1484](https://www.notion.so/oaknationalacademy/Move-Firestore-out-of-Pupil-API-31926cc4e1b180cfa905d3c7e55f5814)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

