### PR TITLE
[ENG-1477] Use existing function module in api module

### DIFF
--- a/modules/gcp_api/functions.tf
+++ b/modules/gcp_api/functions.tf
@@ -1,81 +1,30 @@
-data "google_project" "current" {}
-
 locals {
   function_records = { for f in var.functions : f.entrypoint => f }
-
-  memory_lookup = [
-    "128M",
-    "256M",
-    "512M",
-    "1G",
-    "2G",
-    "4G",
-    "8G",
-    "16G",
-    "32G",
-  ]
 }
 
-resource "google_cloudfunctions2_function" "this" {
+module "functions" {
   for_each = local.function_records
 
-  name        = "${var.name_parts.domain}-${var.env}-${var.name_parts.region}-${var.name_parts.app}-${lower(replace(each.value.entrypoint, "_", "-"))}"
-  location    = var.google_cloud_region
-  description = "The API endpint for ${var.env} ${join(" ", split("-", var.name_parts.app))}, ${each.key}"
+  source = "../gcp_function"
 
-  build_config {
-    runtime           = each.value.runtime
-    entry_point       = each.value.entrypoint
-    docker_repository = "${data.google_project.current.id}/locations/${var.google_cloud_region}/repositories/gcf-artifacts"
-    source {
-      storage_source {
-        bucket = var.function_source_bucket
-        object = each.value.source_object
-      }
-    }
-  }
+  env                 = var.env
+  name_parts          = var.name_parts
+  google_cloud_region = var.google_cloud_region
 
-  service_config {
-    max_instance_count = each.value.max_instance_count
-    available_memory   = local.memory_lookup[each.value.available_memory_pwr]
-    timeout_seconds    = each.value.timeout_seconds
+  entrypoint             = each.value.entrypoint
+  runtime                = each.value.runtime
+  source_object          = each.value.source_object
+  function_source_bucket = var.function_source_bucket
 
-    available_cpu                    = each.value.available_cpu == 0 ? null : each.value.available_cpu
-    max_instance_request_concurrency = each.value.max_request_concurrency
+  max_instance_count      = each.value.max_instance_count
+  available_memory_pwr    = each.value.available_memory_pwr
+  timeout_seconds         = each.value.timeout_seconds
+  available_cpu           = each.value.available_cpu
+  max_request_concurrency = each.value.max_request_concurrency
+  service_account_email   = each.value.service_account_email
+  environment_variables   = each.value.environment_variables
+  secrets                 = each.value.secrets
 
-    service_account_email = each.value.service_account_email
+  description = "The API endpoint for ${var.env} ${join(" ", split("-", var.name_parts.app))}, ${each.key}"
 
-    environment_variables = {
-      for e in concat(
-        each.value.environment_variables,
-        # If one isn't explicitly declared add a LOG_EXECUTION_ID variable (as GCP will do this anyway)
-        contains(
-          [for e in each.value.environment_variables : e.name],
-          "LOG_EXECUTION_ID"
-          ) ? [] : [
-          {
-            name  = "LOG_EXECUTION_ID",
-            value = true,
-          }
-        ]
-      ) : e.name => e.value
-    }
-  }
-}
-
-data "google_iam_policy" "all_users" {
-  binding {
-    role = "roles/run.invoker"
-    members = [
-      "allUsers",
-    ]
-  }
-}
-
-resource "google_cloud_run_v2_service_iam_policy" "policy" {
-  for_each = local.function_records
-
-  location    = google_cloudfunctions2_function.this[each.key].location
-  name        = google_cloudfunctions2_function.this[each.key].name
-  policy_data = data.google_iam_policy.all_users.policy_data
 }

--- a/modules/gcp_api/gateway.tf
+++ b/modules/gcp_api/gateway.tf
@@ -1,6 +1,6 @@
 locals {
   gateway_template_map = {
-    for e in var.gateway.entrypoint_map : e.variable => google_cloudfunctions2_function.this[e.entrypoint].url
+    for e in var.gateway.entrypoint_map : e.variable => module.functions[e.entrypoint].url
   }
 }
 

--- a/modules/gcp_api/variables.tf
+++ b/modules/gcp_api/variables.tf
@@ -107,6 +107,10 @@ variable "functions" {
       name  = string
       value = string
     }))
+    secrets = optional(list(object({
+      env_name    = string
+      secret_name = string
+    })), [])
   }))
   default = []
 

--- a/modules/gcp_function/outputs.tf
+++ b/modules/gcp_function/outputs.tf
@@ -1,0 +1,5 @@
+output "url" {
+  description = "The deployed url for the function"
+  value       = google_cloudfunctions2_function.this.url
+}
+


### PR DESCRIPTION


## Description

- Removes duplicated Terraform code by referencing the gcp_function module locally within gcp_api.

## Issue(s)

[ENG-1477](https://www.notion.so/oaknationalacademy/Use-the-functions-module-in-the-API-module-31226cc4e1b18040bcdfd35834824a38)

## How to test

1. Test in search api using moved blocks to map existing resources to their new address

## Checklist

- [ ] Use latest module in search api and consent api

