### PR TITLE
[ENG-1516] Add sentry project terraform module

### DIFF
--- a/modules/sentry_project/main.tf
+++ b/modules/sentry_project/main.tf
@@ -1,0 +1,24 @@
+data "sentry_organization" "this" {
+  slug = var.sentry_organization_slug
+}
+
+data "sentry_team" "this" {
+  organization = data.sentry_organization.this.slug
+  slug         = var.sentry_team_slug
+}
+
+resource "sentry_project" "this" {
+  organization = data.sentry_organization.this.slug
+
+  teams         = [data.sentry_team.this.slug]
+  name          = var.repo_name
+  slug          = var.repo_name
+  platform      = var.platform
+  default_rules = false
+}
+
+data "sentry_key" "this" {
+  organization = sentry_project.this.organization
+  project      = sentry_project.this.slug
+  first        = true
+}

--- a/modules/sentry_project/outputs.tf
+++ b/modules/sentry_project/outputs.tf
@@ -1,0 +1,5 @@
+output "dsn" {
+  description = "The DSN for the Sentry project."
+  value       = data.sentry_key.this.dsn.public
+  sensitive   = true
+}

--- a/modules/sentry_project/terraform.tf
+++ b/modules/sentry_project/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    sentry = {
+      source  = "jianyuan/sentry"
+      version = "0.15.0-beta1"
+    }
+  }
+}

--- a/modules/sentry_project/variables.tf
+++ b/modules/sentry_project/variables.tf
@@ -1,0 +1,25 @@
+variable "platform" {
+  description = "The platform for the Sentry project."
+  type        = string
+
+  validation {
+    condition     = contains(["javascript-nextjs", "node-express"], var.platform)
+    error_message = "Platform must be one of: javascript-nextjs, node-express."
+  }
+}
+
+variable "repo_name" {
+  description = "The name of the Sentry project.This should be the repo name."
+  type        = string
+}
+
+variable "sentry_organization_slug" {
+  description = "The slug of the Sentry organization."
+  type        = string
+}
+
+variable "sentry_team_slug" {
+  description = "The slug of the Sentry team."
+  type        = string
+  default     = "oak-national-academy"
+}

--- a/modules/sentry_project/variables.tf
+++ b/modules/sentry_project/variables.tf
@@ -21,5 +21,4 @@ variable "sentry_organization_slug" {
 variable "sentry_team_slug" {
   description = "The slug of the Sentry team."
   type        = string
-  default     = "oak-national-academy"
 }

--- a/modules/vercel_project/provider.tf
+++ b/modules/vercel_project/provider.tf
@@ -1,0 +1,3 @@
+provider "vercel" {
+  team = "oak-national-academy"
+}

--- a/modules/vercel_project/terraform.tf
+++ b/modules/vercel_project/terraform.tf
@@ -13,7 +13,3 @@ terraform {
     }
   }
 }
-
-provider "vercel" {
-  team = "oak-national-academy"
-}


### PR DESCRIPTION


## Description

- Creates a reusable Sentry project module that provisions a Sentry project and outputs the DSN for use by other modules.

## Issue(s)

[ENG-1516](https://www.notion.so/oaknationalacademy/Create-Sentry-Terraform-Module-33d26cc4e1b1809d9b5ef2dc91bbce07)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

