### PR TITLE
[ENG-1517] Add optional Sentry integration

### DIFF
--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Terraform Action from oak-terraform-actions
-        uses: oaknational/oak-terraform-actions/actions/terraform-checks@d61b1d03471eeae76166188994f41f3261c57f40 # v1.10.0
+        uses: oaknational/oak-terraform-actions/actions/terraform-checks@1f34878c8996360cb8549b5f12dcb2276b0dcd9d # v1.11.1
         with:
           terraform_base_dir: modules

--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -27,7 +27,44 @@ locals {
     ] })
   ]
 
-  all_env_vars = concat(var.environment_variables, local.custom_env_vars)
+  sentry_vars = concat(
+    var.enable_sentry ? [
+      {
+        key       = "SENTRY_DSN"
+        value     = module.sentry[0].dsn
+        target    = ["production", "preview"]
+        sensitive = true
+      }
+    ] : [],
+    var.enable_sentry ? [
+      for env in ["production", "preview"] : {
+        key       = "SENTRY_ENVIRONMENT"
+        value     = env
+        target    = [env]
+        sensitive = false
+      }
+    ] : [],
+    var.enable_sentry && length(var.custom_environments) > 0 ? flatten([
+      for ce in var.custom_environments : [
+        {
+          key                    = "SENTRY_DSN"
+          value                  = module.sentry[0].dsn
+          target                 = null
+          sensitive              = true
+          custom_environment_ids = [vercel_custom_environment.this[ce.name].id]
+        },
+        {
+          key                    = "SENTRY_ENVIRONMENT"
+          value                  = ce.name
+          target                 = null
+          sensitive              = false
+          custom_environment_ids = [vercel_custom_environment.this[ce.name].id]
+        }
+      ]
+    ]) : []
+  )
+
+  all_env_vars = concat(var.environment_variables, local.custom_env_vars, local.sentry_vars)
 
   detectify_ips = ["52.17.9.21", "52.17.98.131"]
 

--- a/modules/vercel_project/outputs.tf
+++ b/modules/vercel_project/outputs.tf
@@ -1,0 +1,4 @@
+output "sentry_environment_variable_names" {
+  description = "Sentry environment variables added to this project."
+  value       = var.enable_sentry ? "The following Sentry environment variables have been added to the project: 'SENTRY_DSN', 'SENTRY_ENVIRONMENT'" : ""
+}

--- a/modules/vercel_project/sentry.tf
+++ b/modules/vercel_project/sentry.tf
@@ -1,0 +1,9 @@
+module "sentry" {
+  count  = var.enable_sentry ? 1 : 0
+  source = "../sentry_project"
+
+  repo_name                = local.normalized_repo
+  platform                 = var.sentry_platform
+  sentry_organization_slug = var.sentry_organization_slug
+  sentry_team_slug         = var.sentry_team_slug
+}

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -98,6 +98,12 @@ variable "domains" {
   }
 }
 
+variable "enable_sentry" {
+  description = "Whether to create a Sentry project"
+  type        = bool
+  default     = false
+}
+
 variable "environment_variables" {
   description = <<-EOT
     List of environment variable objects.
@@ -114,6 +120,14 @@ variable "environment_variables" {
     sensitive = optional(bool, false)
   }))
   default = []
+
+  validation {
+    condition = !var.enable_sentry || !anytrue([
+      for ev in var.environment_variables :
+      contains(["SENTRY_DSN", "SENTRY_ENVIRONMENT"], ev.key)
+    ])
+    error_message = "SENTRY_DSN and SENTRY_ENVIRONMENT are managed automatically when enable_sentry is true. Remove them from environment_variables."
+  }
 }
 
 variable "expose_system_variables" {
@@ -210,6 +224,34 @@ variable "root_directory" {
   description = "Path to project root within the repo"
   type        = string
   default     = null
+}
+
+variable "sentry_platform" {
+  description = "The platform for the Sentry project."
+  type        = string
+  default     = "javascript-nextjs"
+}
+
+variable "sentry_organization_slug" {
+  description = "The slug of the Sentry organization."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_sentry || var.sentry_organization_slug != null
+    error_message = "sentry_organization_slug must be provided when enable_sentry is true."
+  }
+}
+
+variable "sentry_team_slug" {
+  description = "The slug of the Sentry team."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_sentry || var.sentry_team_slug != null
+    error_message = "sentry_team_slug must be provided when enable_sentry is true."
+  }
 }
 
 variable "skew_protection" {


### PR DESCRIPTION


## Description

- Adds enable_sentry flag to vercel module to optionally create a sentry project

## Issue(s)

[ENG-1517](https://www.notion.so/oaknationalacademy/Update-modules-to-support-Sentry-33d26cc4e1b18033be09dd1783f20fcd)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

