### PR TITLE
[ENG-1526] Optional sentry integration for gcp_api

### DIFF
--- a/modules/gcp_api/functions.tf
+++ b/modules/gcp_api/functions.tf
@@ -22,7 +22,7 @@ module "functions" {
   available_cpu           = each.value.available_cpu
   max_request_concurrency = each.value.max_request_concurrency
   service_account_email   = each.value.service_account_email
-  environment_variables   = each.value.environment_variables
+  environment_variables   = concat(each.value.environment_variables, local.sentry_env_vars)
   secrets                 = each.value.secrets
 
   description = "The API endpoint for ${var.env} ${join(" ", split("-", var.name_parts.app))}, ${each.key}"

--- a/modules/gcp_api/sentry.tf
+++ b/modules/gcp_api/sentry.tf
@@ -1,0 +1,12 @@
+locals {
+  sentry_env_vars = var.enable_sentry ? [
+    {
+      name  = "SENTRY_DSN"
+      value = var.sentry_dsn
+    },
+    {
+      name  = "SENTRY_ENVIRONMENT"
+      value = var.env
+    }
+  ] : []
+}

--- a/modules/gcp_api/variables.tf
+++ b/modules/gcp_api/variables.tf
@@ -23,6 +23,12 @@ variable "name_parts" {
   }
 }
 
+variable "enable_sentry" {
+  description = "Whether to enable Sentry error tracking."
+  type        = bool
+  default     = false
+}
+
 variable "env" {
   description = "The environment"
   type        = string
@@ -166,4 +172,10 @@ variable "gateway" {
     }))
   })
   nullable = true
+}
+
+variable "sentry_dsn" {
+  description = "Sentry DSN"
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION

## Description

- Adds `enable_sentry` flag to `gcp_api` module which injects `SENTRY_DSN` and `SENTRY_ENVIRONMENT` into Cloud Run function environment variables.

## Issue(s)

[ENG-1526](https://www.notion.so/oaknationalacademy/Update-gcp_api-module-to-support-Sentry-34926cc4e1b1803da0e2df0a0a63cbe6)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing

