### PR TITLE
[ENG-1542] Sentry add suffix to project name

### DIFF
--- a/modules/sentry_project/main.tf
+++ b/modules/sentry_project/main.tf
@@ -7,12 +7,16 @@ data "sentry_team" "this" {
   slug         = var.sentry_team_slug
 }
 
+locals {
+  normalized_name = lower(replace("${var.name_parts.git_repo}-${var.name_parts.suffix}", "_", "-"))
+}
+
 resource "sentry_project" "this" {
   organization = data.sentry_organization.this.slug
 
   teams         = [data.sentry_team.this.slug]
-  name          = var.repo_name
-  slug          = var.repo_name
+  name          = local.normalized_name
+  slug          = local.normalized_name
   platform      = var.platform
   default_rules = false
 }

--- a/modules/sentry_project/variables.tf
+++ b/modules/sentry_project/variables.tf
@@ -8,9 +8,12 @@ variable "platform" {
   }
 }
 
-variable "repo_name" {
-  description = "The name of the Sentry project.This should be the repo name."
-  type        = string
+variable "name_parts" {
+  description = "The parts that make up the name. By convention this is the Git repo name and a suffix"
+  type = object({
+    git_repo = string
+    suffix   = string
+  })
 }
 
 variable "sentry_organization_slug" {

--- a/modules/vercel_project/sentry.tf
+++ b/modules/vercel_project/sentry.tf
@@ -2,7 +2,11 @@ module "sentry" {
   count  = var.enable_sentry ? 1 : 0
   source = "../sentry_project"
 
-  repo_name                = local.normalized_repo
+  name_parts = {
+    git_repo = local.normalized_repo
+    suffix   = var.build_type
+  }
+
   platform                 = var.sentry_platform
   sentry_organization_slug = var.sentry_organization_slug
   sentry_team_slug         = var.sentry_team_slug


### PR DESCRIPTION
## Description

- Add a suffix to the Sentry name
- Apply that to the Vercel module

## Issue(s)

[ENG-1542](https://www.notion.so/oaknationalacademy/Allow-a-suffix-to-the-Sentry-project-name-35f26cc4e1b18029bf5eca30437a2f41?v=450b96370cb34a7dacd6994b6a8540c4&source=copy_link)

## How to test

1. Use the module

## Checklist


