### PR TITLE
Add Model Armor env vars to vercel_project module

### DIFF
--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -64,7 +64,75 @@ locals {
     ]) : []
   )
 
-  all_env_vars = concat(var.environment_variables, local.custom_env_vars, local.sentry_vars)
+  model_armor_vars = var.enable_model_armor ? flatten([
+    for target, cfg in {
+      preview    = var.model_armor.preview
+      production = var.model_armor.production
+      } : [
+      {
+        key       = "MODEL_ARMOR_AUTH_MODE"
+        value     = cfg.auth_mode
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_LOCATION"
+        value     = cfg.location
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_PROJECT_ID"
+        value     = cfg.project_id
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_SERVICE_ACCOUNT_EMAIL"
+        value     = cfg.service_account_email
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_TEMPLATE_ID"
+        value     = cfg.template_id
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_WORKLOAD_IDENTITY_PROVIDER_NAME"
+        value     = cfg.workload_identity_provider_name
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_ID"
+        value     = cfg.workload_identity_pool_id
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROVIDER_ID"
+        value     = cfg.workload_identity_pool_provider_id
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROJECT_ID"
+        value     = cfg.workload_identity_pool_project_id
+        target    = [target]
+        sensitive = false
+      },
+      {
+        key       = "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER"
+        value     = cfg.workload_identity_pool_project_number
+        target    = [target]
+        sensitive = false
+      }
+    ]
+  ]) : []
+
+  all_env_vars = concat(var.environment_variables, local.custom_env_vars, local.sentry_vars, local.model_armor_vars)
 
   detectify_ips = ["52.17.9.21", "52.17.98.131"]
 

--- a/modules/vercel_project/outputs.tf
+++ b/modules/vercel_project/outputs.tf
@@ -2,3 +2,19 @@ output "sentry_environment_variable_names" {
   description = "Sentry environment variables added to this project."
   value       = var.enable_sentry ? "The following Sentry environment variables have been added to the project: 'SENTRY_DSN', 'SENTRY_ENVIRONMENT'" : ""
 }
+
+output "model_armor_environment_variable_names" {
+  description = "Model Armor environment variables added to this project."
+  value = var.enable_model_armor ? [
+    "MODEL_ARMOR_AUTH_MODE",
+    "MODEL_ARMOR_LOCATION",
+    "MODEL_ARMOR_PROJECT_ID",
+    "MODEL_ARMOR_SERVICE_ACCOUNT_EMAIL",
+    "MODEL_ARMOR_TEMPLATE_ID",
+    "MODEL_ARMOR_WORKLOAD_IDENTITY_PROVIDER_NAME",
+    "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_ID",
+    "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROVIDER_ID",
+    "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROJECT_ID",
+    "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER",
+  ] : []
+}

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -104,6 +104,12 @@ variable "enable_sentry" {
   default     = false
 }
 
+variable "enable_model_armor" {
+  description = "Whether to inject Model Armor environment variables"
+  type        = bool
+  default     = false
+}
+
 variable "environment_variables" {
   description = <<-EOT
     List of environment variable objects.
@@ -127,6 +133,25 @@ variable "environment_variables" {
       contains(["SENTRY_DSN", "SENTRY_ENVIRONMENT"], ev.key)
     ])
     error_message = "SENTRY_DSN and SENTRY_ENVIRONMENT are managed automatically when enable_sentry is true. Remove them from environment_variables."
+  }
+
+  validation {
+    condition = !var.enable_model_armor || !anytrue([
+      for ev in var.environment_variables :
+      contains([
+        "MODEL_ARMOR_AUTH_MODE",
+        "MODEL_ARMOR_LOCATION",
+        "MODEL_ARMOR_PROJECT_ID",
+        "MODEL_ARMOR_SERVICE_ACCOUNT_EMAIL",
+        "MODEL_ARMOR_TEMPLATE_ID",
+        "MODEL_ARMOR_WORKLOAD_IDENTITY_PROVIDER_NAME",
+        "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_ID",
+        "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROVIDER_ID",
+        "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROJECT_ID",
+        "MODEL_ARMOR_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER",
+      ], ev.key)
+    ])
+    error_message = "Model Armor environment variables are managed automatically when enable_model_armor is true. Remove them from environment_variables."
   }
 }
 
@@ -224,6 +249,42 @@ variable "root_directory" {
   description = "Path to project root within the repo"
   type        = string
   default     = null
+}
+
+variable "model_armor" {
+  description = "Per-target Model Armor configuration to inject into Vercel preview and production environments."
+  type = object({
+    preview = object({
+      auth_mode                             = string
+      location                              = string
+      project_id                            = string
+      service_account_email                 = string
+      template_id                           = string
+      workload_identity_provider_name       = string
+      workload_identity_pool_id             = string
+      workload_identity_pool_provider_id    = string
+      workload_identity_pool_project_id     = string
+      workload_identity_pool_project_number = string
+    })
+    production = object({
+      auth_mode                             = string
+      location                              = string
+      project_id                            = string
+      service_account_email                 = string
+      template_id                           = string
+      workload_identity_provider_name       = string
+      workload_identity_pool_id             = string
+      workload_identity_pool_provider_id    = string
+      workload_identity_pool_project_id     = string
+      workload_identity_pool_project_number = string
+    })
+  })
+  default = null
+
+  validation {
+    condition     = !var.enable_model_armor || var.model_armor != null
+    error_message = "model_armor must be provided when enable_model_armor is true."
+  }
 }
 
 variable "sentry_platform" {


### PR DESCRIPTION
## Description

- add optional Model Armor inputs to `modules/vercel_project`
- inject target-specific `MODEL_ARMOR_*` env vars for Vercel `preview` and `production`
- reserve managed Model Armor env var names when automatic injection is enabled
- add an output listing the managed Model Armor env vars
- Related Cloud Config PR: oaknational/Cloud-Config#532

## Issue(s)

[ENG-###]()

## How to test

1. Run `terraform fmt modules/vercel_project`.
2. Run `terraform -chdir=modules/vercel_project init -backend=false`.
3. Run `terraform -chdir=modules/vercel_project validate`.
4. From a caller repo, pass distinct preview and production Model Armor values and confirm Vercel receives the correct per-target env vars.

## Checklist

- [x] Module-only changes in `oak-terraform-modules`
- [x] No `terraform_remote_state` reads from Cloud Config inside the module
- [x] No consumer-repo wiring in this PR
