### PR TITLE
feat: upgrade vercel project module for provider 5.3

### DIFF
--- a/examples/gcp_function/module.tf
+++ b/examples/gcp_function/module.tf
@@ -15,8 +15,8 @@ module "hosting" {
 
   entrypoint    = "example_function"
   runtime       = "nodejs20"
-  source_object = "example/api_${var.tag_id}.zip" 
-  
+  source_object = "example/api_${var.tag_id}.zip"
+
   service_account_email = var.service_account_email
 
   environment_variables = [
@@ -25,7 +25,7 @@ module "hosting" {
       value = var.env,
     },
   ]
-  
+
   secrets = [
     {
       env_name    = "APP_SIGNING_KEY"

--- a/modules/vercel_project/main.tf
+++ b/modules/vercel_project/main.tf
@@ -89,7 +89,6 @@ resource "vercel_project" "this" {
   install_command                                   = var.install_command
   skew_protection                                   = var.skew_protection
   prioritise_production_builds                      = true
-  protection_bypass_for_automation                  = var.protection_bypass_for_automation
   options_allowlist                                 = local.options_allowlist_obj
   output_directory                                  = var.output_directory
   build_machine_type                                = local.build_machine_type_to_use
@@ -108,6 +107,14 @@ resource "vercel_project" "this" {
   resource_config = {
     function_default_regions = ["lhr1"] // London
   }
+}
+
+resource "vercel_project_protection_bypass" "this" {
+  count = var.protection_bypass_for_automation ? 1 : 0
+
+  project_id = vercel_project.this.id
+  is_env_var = true
+  note       = "Managed by Terraform"
 }
 
 resource "vercel_project_domain" "this" {

--- a/modules/vercel_project/outputs.tf
+++ b/modules/vercel_project/outputs.tf
@@ -2,3 +2,8 @@ output "sentry_environment_variable_names" {
   description = "Sentry environment variables added to this project."
   value       = var.enable_sentry ? "The following Sentry environment variables have been added to the project: 'SENTRY_DSN', 'SENTRY_ENVIRONMENT'" : ""
 }
+
+output "project_id" {
+  description = "The Vercel project ID."
+  value       = vercel_project.this.id
+}

--- a/modules/vercel_project/terraform.tf
+++ b/modules/vercel_project/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 3.14.1"
+      version = "~> 5.3.0"
     }
   }
 }

--- a/modules/vercel_project/variables.tf
+++ b/modules/vercel_project/variables.tf
@@ -48,7 +48,8 @@ variable "custom_environments" {
 
   validation {
     condition = alltrue([
-      for env in var.custom_environments : can(regex("${var.cloudflare_zone_domain}$", env.domain))
+      for env in var.custom_environments :
+      env.domain == var.cloudflare_zone_domain || endswith(env.domain, ".${var.cloudflare_zone_domain}")
     ])
     error_message = <<-EOT
       Domain must end with '${var.cloudflare_zone_domain}'
@@ -89,7 +90,7 @@ variable "domains" {
   validation {
     condition = alltrue([
       for domain in var.domains :
-      can(regex("${var.cloudflare_zone_domain}$", domain))
+      domain == var.cloudflare_zone_domain || endswith(domain, ".${var.cloudflare_zone_domain}")
     ])
     error_message = <<-EOT
       Domain must end with '${var.cloudflare_zone_domain}'


### PR DESCRIPTION
## Description

- upgrade the shared `modules/vercel_project` module to `vercel/vercel ~> 5.3.0`
- replace the legacy inline project protection bypass setting with `vercel_project_protection_bypass`, guarded by the existing boolean
- export `project_id` and fix domain validation to use literal suffix checks with dot-boundary semantics

## Issue(s)

- Follow-up for oaknational/school-picker-service#4

## How to test

1. `terraform fmt -recursive`
2. `terraform -chdir=modules/vercel_project init -backend=false`
3. `terraform -chdir=modules/vercel_project validate`

## Checklist

- [x] Provider constraint bumped to `vercel/vercel ~> 5.3.0`
- [x] `protection_bypass_for_automation` preserved via `vercel_project_protection_bypass`
- [x] `project_id` output added
