### PR TITLE
feat(gcp_sql): allow numeric characters in name_parts

### DIFF
--- a/modules/gcp_sql/variables.tf
+++ b/modules/gcp_sql/variables.tf
@@ -19,8 +19,8 @@ variable "name_parts" {
   }
 
   validation {
-    condition     = can(regex("^[a-z-]+$", join("-", values(var.name_parts))))
-    error_message = "Name parts should only contain lowercase letters or -"
+    condition     = can(regex("^[a-z0-9-]+$", join("-", values(var.name_parts))))
+    error_message = "Name parts should only contain lowercase letters, numbers, or -"
   }
 }
 


### PR DESCRIPTION
## Summary
- Relaxes `name_parts` validation regex from `^[a-z-]+$` to `^[a-z0-9-]+$` to support keys like `curriculum2`
- Updates error message to mention numbers are allowed

Part of ENG-1547